### PR TITLE
task: make the current year dynamic

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def current_year
+    Date.current.year
+  end
 end

--- a/app/views/public/index.html.erb
+++ b/app/views/public/index.html.erb
@@ -181,7 +181,7 @@
   <div class="flex flex-col items-center justify-between border-t border-grey-lighter py-10 sm:flex-row sm:py-12">
     <div class="mr-auto flex flex-col items-center sm:flex-row">
       <p class="pt-5 font-body font-light text-primary dark:text-white sm:pt-0">
-        ©2023 | Ruby Latam
+        ©<%= current_year %> | Ruby Latam
       </p>
     </div>
     <div class="mr-auto flex items-center pt-5 sm:mr-0 sm:pt-0">

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,9 @@
+# test/helpers/application_helper_test.rb
+
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  test 'current_year returns the current year' do
+    assert_equal Date.current.year, current_year
+  end
+end


### PR DESCRIPTION
At the beginning it has the year 2023 hardcoded in the view, however we need to have that dynamic and instead of add the logic directly into the view, we have created a helper which has its own test:

The way to run the tests is:
```
bundle exec rails test
```

It's the first test in the rails test suite. 

Here's the result

![Screenshot 2025-01-14 at 4 29 49 PM](https://github.com/user-attachments/assets/f99e7877-00ea-410c-b42d-542e361cec85)
